### PR TITLE
`height: 100vh` is not limited to the screen, so `position: absolute` is used instead

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,11 @@
   display: grid;
   grid-template-columns: minmax(500px, 1fr) auto;
   grid-template-rows: minmax(240px, 1fr) auto;
-  height: 100vh;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .parts-search-area {


### PR DESCRIPTION
#15 から分割しました (cc @graphemecluster)

`height: 100vh` はスクリーンの高さとは限らないので代わりに `position: absolute` を使用