### PR TITLE
Prevent right-clicking on the glyph area from opening context menu

### DIFF
--- a/src/components/GlyphArea.tsx
+++ b/src/components/GlyphArea.tsx
@@ -91,6 +91,7 @@ const GlyphArea = () => {
       <svg
         width="100%" height="100%" viewBox="-20 -20 500 240"
         className={svgClassName}
+        onContextMenu={(evt) => evt.preventDefault()}
         onMouseDownCapture={handleMouseDownCapture}
         onMouseDown={handleMouseDownBackground}
       >


### PR DESCRIPTION
#15 から分割しました (cc @graphemecluster)

グリフエリアの右クリックでコンテキストメニューが開かないようにする