### PR TITLE
Prefer eslint's switch-exhaustiveness-check over assigning to never type

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -161,6 +161,11 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
 
+      '@typescript-eslint/switch-exhaustiveness-check': [
+        'warn',
+        { requireDefaultForNonUnion: true },
+      ],
+
       // TODO: activate these rules
       '@typescript-eslint/no-explicit-any': 'off',
       'prefer-const': 'off',

--- a/src/components/SelectionControl.tsx
+++ b/src/components/SelectionControl.tsx
@@ -81,10 +81,16 @@ const selectionControlSelector = createSelector(
             pointIndex: (i - 3) / 2,
           });
           let className = '';
-          if (matchType === MatchType.match) {
-            className = 'match';
-          } else if (matchType === MatchType.online) {
-            className = 'online';
+          switch (matchType) {
+            case MatchType.match:
+              className = 'match';
+              break;
+            case MatchType.online:
+              className = 'online';
+              break;
+            case MatchType.none:
+              className = '';
+              break;
           }
 
           pointControl.push({

--- a/src/components/StrokeCenterLine.tsx
+++ b/src/components/StrokeCenterLine.tsx
@@ -35,9 +35,6 @@ const strokeCenterLineShownNumbersSelector = createSelector(
       }
       case ShowCenterLine.always:
         return glyph.map((_gLine, index) => index);
-      default:
-        // exhaustive?
-        return ((_x: never) => _x)(showStrokeCenterLine);
     }
   }
 );

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -27,7 +27,7 @@ const resources = {
   },
 };
 
-let lng = 'ja';
+let lng: keyof typeof resources;
 switch (args.host.split('.')[0]) {
   case 'en':
     lng = 'en';
@@ -40,6 +40,9 @@ switch (args.host.split('.')[0]) {
     break;
   case 'zht':
     lng = 'zh-Hant';
+    break;
+  default:
+    lng = 'ja';
     break;
 }
 

--- a/src/kageUtils/connection.ts
+++ b/src/kageUtils/connection.ts
@@ -118,6 +118,8 @@ const getConnectablePoints = (glyphLine: GlyphLine): ConnectablePoint[] => {
       });
       break;
     }
+    default:
+      break;
   }
   return result;
 };

--- a/src/kageUtils/freehand.ts
+++ b/src/kageUtils/freehand.ts
@@ -386,6 +386,9 @@ const snapStrokeTilt = (newStroke: GlyphLine) => {
       return;
     case 7:
       newStroke.value[5] = newStroke.value[7] = newStroke.value[3];
+      return;
+    default:
+      return;
   }
 };
 const snapStrokeEnd = (glyph: Glyph, newStroke: GlyphLine): Glyph => {

--- a/src/kageUtils/match.ts
+++ b/src/kageUtils/match.ts
@@ -63,6 +63,8 @@ export const getMatchType = (glyph: Glyph, point: PointDescriptor): MatchType =>
           result = MatchType.online;
         }
         break;
+      default:
+        break;
     }
   }
   return result;

--- a/src/selectors/draggedGlyph.ts
+++ b/src/selectors/draggedGlyph.ts
@@ -46,15 +46,15 @@ export const resizeSelected = (glyph: Glyph, selection: number[], position: Rect
             newValue[3] = Math.round(newValue[3] + dx);
             newValue[4] = Math.round(newValue[4] + dy);
             break;
-          default:
-            // exhaustive?
-            ((x: never) => x)(position);
         }
         const newGlyphLine: GlyphLine = selectedGlyphLine.value[0] === 99
           ? { value: newValue, partName: selectedGlyphLine.partName }
           : { value: newValue };
         return glyph.map((glyphLine, index) => index === selection[0] ? newGlyphLine : glyphLine);
       }
+      default:
+        // not expected to reach here...
+        break;
     }
   }
   const minSize = 20;
@@ -89,9 +89,6 @@ export const resizeSelected = (glyph: Glyph, selection: number[], position: Rect
       newBBX[0] = Math.min(newBBX[0] + dx, newBBX[2] - minSize);
       newBBX[1] = Math.min(newBBX[1] + dy, newBBX[3] - minSize);
       break;
-    default:
-      // exhaustive?
-      ((x: never) => x)(position);
   }
   return resizeSelectedGlyphLines(glyph, selection, oldBBX, newBBX);
 };


### PR DESCRIPTION
Require every switch statement to be exhaustive with the ESLint rule `@typescript-eslint/switch-exhaustiveness-check` to catch bugs with forgotten cases