### PR TITLE
Fix long parts name overflowing

### DIFF
--- a/src/components/PartsSearch.module.css
+++ b/src/components/PartsSearch.module.css
@@ -28,8 +28,10 @@
 }
 
 .partsHoverName {
+  width: 240px;
   height: 1.3em;
   line-height: 1.3;
+  overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
Fixed an issue where hovering over a glyph with a long name in the search area would cause the width of the search area to expand.

The screenshot describing the (now fixed) issue:
<img width="1200" height="800" alt="kage_editor_long" src="https://github.com/user-attachments/assets/99933157-c8f4-4965-bc71-4c37e5f24dfb" />
